### PR TITLE
Check secondary hours before logging processing

### DIFF
--- a/pixl_imaging/src/pixl_imaging/_processing.py
+++ b/pixl_imaging/src/pixl_imaging/_processing.py
@@ -77,6 +77,11 @@ async def _process_message(
         - send the study to Orthanc Anon
     """
     await orthanc_raw.raise_if_pending_jobs()
+
+    if archive.name == "secondary" and (_is_daytime() or _is_weekend()):
+        msg = "Not querying secondary archive during the daytime or on the weekend."
+        raise PixlOutOfHoursError(msg)
+
     logger.info("Processing: {}. Querying {} archive.", study.message.identifier, archive.name)
 
     study_query_id = await _find_study_in_archive_or_raise(
@@ -242,10 +247,6 @@ async def _find_study_in_archive_or_raise(
     the MRN and accession number.
 
     """
-    if archive.name == "secondary" and (_is_daytime() or _is_weekend()):
-        msg = "Not querying secondary archive during the daytime or on the weekend."
-        raise PixlOutOfHoursError(msg)
-
     query_id = await _find_study_in_archive(
         orthanc_raw=orthanc_raw,
         study=study,


### PR DESCRIPTION
That way don't have INFO level logs of processing messages from secondary queue before 8pm