### PR TITLE
Reset start time if pending status

### DIFF
--- a/pixl_imaging/src/pixl_imaging/_orthanc.py
+++ b/pixl_imaging/src/pixl_imaging/_orthanc.py
@@ -166,8 +166,9 @@ class Orthanc(ABC):
                 msg = f"Failed to finish {job_type} job {job_id} in {timeout} seconds"
                 await sleep(10)
                 raise PixlDiscardError(msg)
-
             await sleep(10)
+            if job_info["State"] == "Pending":
+                start_time = time()
             job_info = await self.job_state(job_id=job_id)
 
     async def job_state(self, job_id: str) -> Any:


### PR DESCRIPTION
If a job is pending for a long time then it can timeout currently, which shouldn't happen