### PR TITLE
Add configuration for IoN Neuro DB project

### DIFF
--- a/projects/configs/ion-neuro-db.yaml
+++ b/projects/configs/ion-neuro-db.yaml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022 University College London Hospitals NHS Foundation Trust
+#  Copyright (c) 2024 University College London Hospitals NHS Foundation Trust
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/projects/configs/ion-neuro-db.yaml
+++ b/projects/configs/ion-neuro-db.yaml
@@ -1,0 +1,34 @@
+#  Copyright (c) 2022 University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+project:
+    name: "ion-neuro-db"
+    modalities: ["MR"]
+
+tag_operation_files:
+    base:
+        - "base.yaml" #Expected base config file for any project
+        - "mri.yaml"
+        - "ion-neuro-db.yaml"
+    manufacturer_overrides: ["mri.yaml"]
+
+series_filters:
+    - "localizer"
+    - "localiser"
+    - "scout"
+    - "positioning"
+
+destination:
+    dicom: "dicomweb"
+    parquet: "none"

--- a/projects/configs/ion-neuro-db.yaml
+++ b/projects/configs/ion-neuro-db.yaml
@@ -30,5 +30,5 @@ series_filters:
     - "positioning"
 
 destination:
-    dicom: "dicomweb"
-    parquet: "none"
+    dicom: "xnat"
+    parquet: "ftps"

--- a/projects/configs/prognosis-ai.yaml
+++ b/projects/configs/prognosis-ai.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 project:
-    name: "ion-neuro-db"
+    name: "prognosis-ai"
     modalities: ["MR"]
 
 tag_operation_files:
@@ -30,5 +30,5 @@ series_filters:
     - "positioning"
 
 destination:
-    dicom: "xnat"
-    parquet: "ftps"
+    dicom: "none"
+    parquet: "none"

--- a/projects/configs/tag-operations/ion-neuro-db.yaml
+++ b/projects/configs/tag-operations/ion-neuro-db.yaml
@@ -1,0 +1,26 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Specific tag operations for ion-neuro-db project
+
+- name: "Study Date"
+  group: 0x0008
+  element: 0x0020
+  op: "keep"
+- name: "Acquisition Date"
+  group: 0x0008
+  element: 0x0022
+  op: "keep"
+
+

--- a/projects/configs/tag-operations/ion-neuro-db.yaml
+++ b/projects/configs/tag-operations/ion-neuro-db.yaml
@@ -14,10 +14,6 @@
 
 # Specific tag operations for ion-neuro-db project
 
-- name: "Study Date"
-  group: 0x0008
-  element: 0x0020
-  op: "keep"
 - name: "Acquisition Date"
   group: 0x0008
   element: 0x0022


### PR DESCRIPTION
Creating default configuration for IoN Neuro DB project. 

We override sequentually so the first file to be read is the
- [projects/configs/tag-operations/base.yaml](https://github.com/SAFEHR-data/PIXL/blob/main/projects/configs/tag-operations/base.yaml)
- then [projects/configs/tag-operations/mri.yaml](https://github.com/SAFEHR-data/PIXL/blob/main/projects/configs/tag-operations/mri.yaml)
- and specific to this project: [projects/configs/tag-operations/ion-neuro-db.yaml](https://github.com/SAFEHR-data/PIXL/blob/main/projects/configs/tag-operations/ion-neuro-db.yaml)
- Then for specific manufacturers: [projects/configs/tag-operations/manufacturer-overrides/mri.yaml](https://github.com/SAFEHR-data/PIXL/blob/main/projects/configs/tag-operations/manufacturer-overrides/mri.yaml)