### PR TITLE
Fix timeout issues when querying instances of a local study in Orthanc

### DIFF
--- a/pixl_imaging/src/pixl_imaging/_orthanc.py
+++ b/pixl_imaging/src/pixl_imaging/_orthanc.py
@@ -64,6 +64,10 @@ class Orthanc:
         """Query local Orthanc instance for study."""
         return await self._get(f"/studies/{study_id}")
 
+    async def get_local_study_statistics(self, study_id: str) -> Any:
+        """Query local Orthanc instance for study statistics."""
+        return await self._get(f"/studies/{study_id}/statistics")
+
     async def get_local_study_instances(self, study_id: str) -> Any:
         """Get the instances of a study."""
         return await self._get(

--- a/pixl_imaging/src/pixl_imaging/_orthanc.py
+++ b/pixl_imaging/src/pixl_imaging/_orthanc.py
@@ -66,7 +66,10 @@ class Orthanc:
 
     async def get_local_study_instances(self, study_id: str) -> Any:
         """Get the instances of a study."""
-        return await self._get(f"/studies/{study_id}/instances")
+        return await self._get(
+            f"/studies/{study_id}/instances?short=true",
+            timeout=self.dicom_timeout,  # this API call can sometimes take several minutes
+        )
 
     async def query_remote(self, data: dict, modality: str) -> Optional[str]:
         """Query a particular modality, available from this node"""
@@ -154,13 +157,15 @@ class Orthanc:
         # See: https://book.orthanc-server.com/users/advanced-rest.html#jobs-monitoring
         return await self._get(f"/jobs/{job_id}")
 
-    async def _get(self, path: str) -> Any:
+    async def _get(self, path: str, timeout: int | None = None) -> Any:
+        # Optionally override default http timeout
+        http_timeout = timeout or self.http_timeout
         async with (
             aiohttp.ClientSession() as session,
             session.get(
                 f"{self._url}{path}",
                 auth=self._auth,
-                timeout=self.http_timeout,
+                timeout=http_timeout,
             ) as response,
         ):
             return await _deserialise(response)

--- a/pixl_imaging/src/pixl_imaging/_processing.py
+++ b/pixl_imaging/src/pixl_imaging/_processing.py
@@ -300,7 +300,7 @@ async def _get_missing_instances(
 
     num_local_instances = 0
     for resource in resources:
-        study_statistics = orthanc_raw.get_local_study_statistics(study_id=resource)
+        study_statistics = await orthanc_raw.get_local_study_statistics(study_id=resource)
         num_local_instances += int(study_statistics["CountInstances"])
 
     if num_remote_instances == num_local_instances:

--- a/pixl_imaging/src/pixl_imaging/_processing.py
+++ b/pixl_imaging/src/pixl_imaging/_processing.py
@@ -283,15 +283,9 @@ async def _get_missing_instances(
 
     Return a list of missing instance UIDs (empty if none missing)
     """
-    # First get all SOPInstanceUIDs for the study that are in Orthanc Raw
-    orthanc_raw_sop_instance_uids = []
-    for resource in resources:
-        study_instances = await orthanc_raw.get_local_study_instances(study_id=resource)
-        orthanc_raw_sop_instance_uids.extend(
-            [instance["MainDicomTags"]["SOPInstanceUID"] for instance in study_instances]
-        )
+    missing_instances: list[dict[str, str]] = []
 
-    # Now query the VNA / PACS for the study instances
+    # First query the VNA / PACS for the study instances
     study_query_answers = await orthanc_raw.get_remote_query_answers(study_query_id)
     instances_queries_and_answers = []
     for answer_id in study_query_answers:
@@ -302,12 +296,24 @@ async def _get_missing_instances(
         instances_queries_and_answers.extend(
             [(instances_query_id, answer) for answer in instances_query_answers]
         )
+    num_remote_instances = len(instances_queries_and_answers)
 
-    missing_instances: list[dict[str, str]] = []
+    num_local_instances = 0
+    for resource in resources:
+        study_statistics = orthanc_raw.get_local_study_statistics(study_id=resource)
+        num_local_instances += int(study_statistics["CountInstances"])
 
-    if len(instances_queries_and_answers) == len(orthanc_raw_sop_instance_uids):
+    if num_remote_instances == num_local_instances:
         logger.debug("No missing instances for study {}", study.message.study_uid)
         return missing_instances
+
+    # Get all SOPInstanceUIDs for the study that are in Orthanc Raw
+    orthanc_raw_sop_instance_uids = []
+    for resource in resources:
+        study_instances = await orthanc_raw.get_local_study_instances(study_id=resource)
+        orthanc_raw_sop_instance_uids.extend(
+            [instance["MainDicomTags"]["0008,0018"] for instance in study_instances]
+        )
 
     # If the SOPInstanceUID is not in the list of instances in Orthanc Raw
     # retrieve the instance from the VNA / PACS


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
## Description
Fixes #531

- use the DICOM timeout when getting info on the instances in a study
- when determining if there are any instances missing, first get statistics of the study and compare the number of local and remote instances (if all instances are present locally there's no need to get the list of `SOPInstanceUIDs`)

## Type of change
Please delete options accordingly to the description.

<!-- Write an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Suggested Checklist
<!-- You do not need to complete all the items by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have passed on my local host device. (see further details at the [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md#local-testing) document)
- [ ] Make sure your branch is up-to-date with main branch. See [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md) for a general example to syncronise your branch with the `main` branch.
- [ ] I have requested review to this PR.
- [ ] I have addressed and marked as resolved all the review comments in my PR.
- [ ] Finally, I have selected `squash and merge`

