### PR TITLE
Fix intermittent system tests failure caused by creating the output directory twice

### DIFF
--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -195,10 +195,10 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
 
 def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
     try:
-        ftp.cwd(project_dir)
-        logger.debug("'{}' exists on remote ftp, so moving into it", project_dir)
-    except ftplib.error_perm:
-        logger.info("creating '{}' on remote ftp and moving into it", project_dir)
-        # Directory doesn't exist, so create it
         ftp.mkd(project_dir)
-        ftp.cwd(project_dir)
+    except ftplib.error_perm:
+        logger.debug("'{}' exists on remote ftp, so moving into it", project_dir)
+    else:
+        logger.info("created '{}' on remote ftp and moving into it", project_dir)
+
+    ftp.cwd(project_dir)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
## Description
Fixes #589

- always try to create the folder and ignore the exception if it already exists. Previously we would check for existence and create it if necessary. But we sometime attempted to create the same folder twice during concurrent uploads

## Type of change
Please delete options accordingly to the description.

<!-- Write an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Suggested Checklist
<!-- You do not need to complete all the items by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have passed on my local host device. (see further details at the [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md#local-testing) document)
- [ ] Make sure your branch is up-to-date with main branch. See [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md) for a general example to syncronise your branch with the `main` branch.
- [ ] I have requested review to this PR.
- [ ] I have addressed and marked as resolved all the review comments in my PR.
- [ ] Finally, I have selected `squash and merge`

