### PR TITLE
Adds test to check modalities not specified in project config are dropped

### DIFF
--- a/pixl_dcmd/tests/test_main.py
+++ b/pixl_dcmd/tests/test_main.py
@@ -123,6 +123,8 @@ def test_drop_unspecified_modalities(test_project_config: PixlConfig) -> None:
     with pytest.raises(PixlSkipInstanceError):
         anonymise_dicom(ds_mr, config=test_project_config)
 
+    assert ds_mr.Modality not in test_project_config.project.modalities
+
 
 def test_enforce_allowlist_removes_overlay_plane() -> None:
     """Checks that overlay planes are removed."""

--- a/pixl_dcmd/tests/test_main.py
+++ b/pixl_dcmd/tests/test_main.py
@@ -110,6 +110,14 @@ def test_drop_unspecified_modalities(test_project_config: PixlConfig) -> None:
     WHEN the modality tag in the DICOM files does not match the specified modalities in the configuration
     THEN drop those DICOM files
     """
+    ds_dx = generate_dicom_dataset(Modality="DX")
+    ds_cr = generate_dicom_dataset(Modality="CR")
+
+    anonymise_dicom(ds_dx, config=test_project_config)
+    anonymise_dicom(ds_cr, config=test_project_config)
+
+    assert ds_dx.Modality in test_project_config.project.modalities
+    assert ds_cr.Modality in test_project_config.project.modalities
 
 
 def test_enforce_allowlist_removes_overlay_plane() -> None:

--- a/pixl_dcmd/tests/test_main.py
+++ b/pixl_dcmd/tests/test_main.py
@@ -103,6 +103,15 @@ def mri_diffusion_dicom_image(test_project_config: PixlConfig) -> pydicom.Datase
     return ds
 
 
+@pytest.mark.usefixtures()
+def test_drop_unspecified_modalities(test_project_config: PixlConfig) -> None:
+    """
+    GIVEN a project configuration and DICOM files
+    WHEN the modality tag in the DICOM files does not match the specified modalities in the configuration
+    THEN drop those DICOM files
+    """
+
+
 def test_enforce_allowlist_removes_overlay_plane() -> None:
     """Checks that overlay planes are removed."""
     ds = pydicom.data.get_testdata_file(

--- a/pixl_dcmd/tests/test_main.py
+++ b/pixl_dcmd/tests/test_main.py
@@ -103,29 +103,6 @@ def mri_diffusion_dicom_image(test_project_config: PixlConfig) -> pydicom.Datase
     return ds
 
 
-@pytest.mark.usefixtures()
-def test_drop_unspecified_modalities(test_project_config: PixlConfig) -> None:
-    """
-    GIVEN a project configuration and DICOM files
-    WHEN the modality tag in the DICOM files does not match the specified modalities in the configuration
-    THEN drop those DICOM files
-    """
-    ds_dx = generate_dicom_dataset(Modality="DX")
-    ds_cr = generate_dicom_dataset(Modality="CR")
-    ds_mr = generate_dicom_dataset(Modality="MR")  # not in config
-
-    anonymise_dicom(ds_dx, config=test_project_config)
-    anonymise_dicom(ds_cr, config=test_project_config)
-
-    assert ds_dx.Modality in test_project_config.project.modalities
-    assert ds_cr.Modality in test_project_config.project.modalities
-
-    with pytest.raises(PixlSkipInstanceError):
-        anonymise_dicom(ds_mr, config=test_project_config)
-
-    assert ds_mr.Modality not in test_project_config.project.modalities
-
-
 def test_enforce_allowlist_removes_overlay_plane() -> None:
     """Checks that overlay planes are removed."""
     ds = pydicom.data.get_testdata_file(
@@ -265,6 +242,29 @@ def test_anonymisation_with_overrides(
     assert (0x2001, 0x1003) in mri_diffusion_dicom_image
     assert mri_diffusion_dicom_image.PatientID != original_patient_id
     assert mri_diffusion_dicom_image[(0x2001, 0x1003)] == original_private_tag
+
+
+@pytest.mark.usefixtures()
+def test_drop_unspecified_modalities(test_project_config: PixlConfig) -> None:
+    """
+    GIVEN a project configuration and DICOM files
+    WHEN the modality tag in the DICOM files does not match the specified modalities in the configuration
+    THEN drop those DICOM files
+    """
+    ds_dx = generate_dicom_dataset(Modality="DX")
+    ds_cr = generate_dicom_dataset(Modality="CR")
+    ds_mr = generate_dicom_dataset(Modality="MR")  # not in config
+
+    anonymise_dicom(ds_dx, config=test_project_config)
+    anonymise_dicom(ds_cr, config=test_project_config)
+
+    assert ds_dx.Modality in test_project_config.project.modalities
+    assert ds_cr.Modality in test_project_config.project.modalities
+
+    with pytest.raises(PixlSkipInstanceError):
+        anonymise_dicom(ds_mr, config=test_project_config)
+
+    assert ds_mr.Modality not in test_project_config.project.modalities
 
 
 @pytest.mark.usefixtures("rows_in_session")


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
## Description
Fixes #193:

This PR adds a unit test to `pixl_dcmd` which creates three DICOM datasets, 2 which match the modalities field within `test_project_config` and 1 which does not match. The test uses the `anonymise_dicom()` function and confirms that the "MR" dataset is dropped because it is not in the project config. 

It also asserts true the modalities within the config, and asserts not true modalities omitted from the config.

## Type of change
Please delete options accordingly to the description.

<!-- Write an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Suggested Checklist
<!-- You do not need to complete all the items by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have passed on my local host device. (see further details at the [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md#local-testing) document)
- [x] Make sure your branch is up-to-date with main branch. See [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md) for a general example to syncronise your branch with the `main` branch.
- [x] I have requested review to this PR.
- [ ] I have addressed and marked as resolved all the review comments in my PR.
- [x] Finally, I have selected `squash and merge`

