### PR TITLE
Docker Compose profile for external PIXL DB

### DIFF
--- a/cli/src/pixl_cli/_config.py
+++ b/cli/src/pixl_cli/_config.py
@@ -37,6 +37,9 @@ SERVICE_SETTINGS = {
     },
 }  # type: dict
 
+if config("POSTGRES_EXTERNAL_PORT"):
+    SERVICE_SETTINGS["postgres"]["port"] = int(config("POSTGRES_EXTERNAL_PORT"))
+
 
 class APIConfig:
     """API Configuration"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ volumes:
     orthanc-anon-data:
     orthanc-raw-data:
     postgres-data:
+    external-pixl-db-data:
     exports:
     rabbitmq:
 
@@ -372,6 +373,35 @@ services:
               target: /var/lib/postgresql/data
         ports:
             - "${POSTGRES_PORT}:5432"
+        healthcheck:
+            test: ["CMD", "pg_isready", "-U", "${PIXL_DB_USER}", "--dbname", "${PIXL_DB_NAME}"]
+            interval: 10s
+            timeout: 30s
+            retries: 5
+        restart: always
+        networks:
+            - pixl-net
+    postgres-external:
+        profiles: [external-pixl-db]
+        build:
+            context: .
+            dockerfile: ./docker/postgres/Dockerfile
+            args:
+                <<: *build-args-common
+        environment:
+            POSTGRES_USER: ${PIXL_DB_USER}
+            POSTGRES_PASSWORD: ${PIXL_DB_PASSWORD}
+            POSTGRES_DB: ${PIXL_DB_NAME}
+            PGTZ: ${TZ:-Europe/London}
+        env_file:
+            - ./docker/common.env
+        command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
+        volumes:
+            - type: volume
+              source: external-pixl-db-data
+              target: /var/lib/postgresql/data
+        ports:
+            - "${POSTGRES_EXTERNAL_PORT}:5432"
         healthcheck:
             test: ["CMD", "pg_isready", "-U", "${PIXL_DB_USER}", "--dbname", "${PIXL_DB_NAME}"]
             interval: 10s

--- a/test/.env
+++ b/test/.env
@@ -15,6 +15,9 @@ PIXL_DB_USER=pixl_db_username
 PIXL_DB_PASSWORD=pixl_db_password
 SKIP_ALEMBIC=false
 
+# External postgres
+POSTGRES_EXTERNAL_PORT=7011
+
 # Exposed ports
 HASHER_API_PORT=7010
 POSTGRES_PORT=7001

--- a/test/run-system-test.sh
+++ b/test/run-system-test.sh
@@ -28,14 +28,14 @@ setup() {
     # Warning: Requires to be run from the project root
     (
     	cd "${PACKAGE_DIR}"
-    	docker compose --env-file test/.env --env-file test/.secrets.env -p system-test up --wait -d --build
+    	docker compose --env-file test/.env --env-file test/.secrets.env --profile external-pixl-db -p system-test up --wait -d --build
     )
 }
 
 teardown() {
     (
     	cd "${PACKAGE_DIR}"
-    	docker compose -f docker-compose.yml -f test/docker-compose.yml -p system-test down --volumes
+    	docker compose -f docker-compose.yml -f test/docker-compose.yml --profile external-pixl-db -p system-test down --volumes
     )
 }
 


### PR DESCRIPTION
@p-j-smith, @stefpiatek – draft PR alternative approach to #593, to hopefully demonstrate this is along the right lines.

Uses Docker Compose profiles approach, as discussed in that PR. Thought simpler to start again from `main` rather than unpick the other one.

I've got two postgres containers running with `./run-system-test.sh`, however the system-tests are failing hard. I can't figure out why yet. I think pixl cli is unable to communicate with system-test-postgres-external-1.

If either of you has a chance to pull the branch and investigate the system tests errors, let me know if you can diagnose, otherwise I'll keep at it.
