### PR TITLE
Add support for Docker Compose<22.0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,19 +4,18 @@ PIXL_QUERY_TIMEOUT=10
 CLI_RETRY_SECONDS=300
 
 # PIXL PostgreSQL instance
-PIXL_DB_HOST=postgres-exposed
+PIXL_DB_HOST=postgres
 PIXL_DB_PORT=5432
 PIXL_DB_NAME=pixl
 PIXL_DB_USER=pixl
 PIXL_DB_PASSWORD=
 SKIP_ALEMBIC=false
-EXTERNAL_PIXL_DB=false
 
 # PIXL DB Postgres host
 CLI_PIXL_DB_HOST=localhost
 
 # Orthanc Raw PostgreSQL instance
-ORTHANC_RAW_DB_HOST=postgres-exposed  # change to correct host if PIXL DB is external postgres instance
+ORTHANC_RAW_DB_HOST=postgres
 ORTHANC_RAW_DB_PORT=5432
 ORTHANC_RAW_DB_NAME=pixl
 ORTHANC_RAW_DB_USER=pixl

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,34 +29,17 @@ See general pixl commands and subcommands with:
 pixl --help
 ```
 
-### Starting PIXL
-
 For convenience, we provide the `pixl dc` command, which acts as a wrapper for `docker compose`,
 but takes care of some of the configuration for you.
 
-**1) Default Start-up**
+For example,
 
 ```bash
 pixl dc up
 ```
 
-**2) Start-up with External PIXL DB**
-
-PIXL can be set up so that the PIXL DB uses a separate postgres instance to Orthanc Raw, e.g. for production environment configurations. 
-Edit the .env file to enable this:
-
-```bash
-EXTERNAL_PIXL_DB=true
-
-CLI_PIXL_DB_PORT=7001
-
-ORTHANC_RAW_DB_HOST=postgres
-```
-
-Start-up PIXL:
-```bash
-pixl dc up
-```
+will run `docker compose --project pixl_{pixl_env} up --wait --build --remove-orphans`, where `pixl_env`
+is determined by the `ENV` environment variable.
 
 ### Configuration
 

--- a/cli/src/pixl_cli/_docker_commands.py
+++ b/cli/src/pixl_cli/_docker_commands.py
@@ -34,25 +34,11 @@ def dc(args: tuple[str]) -> None:
     docker_args = list(args)
 
     if "up" in args:
-        docker_args = _parse_up_args(args)
+        docker_args = [*args, "--wait", "--build", "--remove-orphans"]
     if "down" in args:
         docker_args = _check_down_args(args)
 
     run_docker_compose(docker_args, working_dir=PIXL_ROOT)
-
-
-def _parse_up_args(args: tuple[str, ...]) -> list:
-    """Check up args and set docker compose profile"""
-    args_list = list(args)
-
-    up_index = args.index("up")
-    external_pixl_db_env = config("EXTERNAL_PIXL_DB", cast=bool)
-    args_list[up_index:up_index] = (
-        ["--profile", "postgres"] if external_pixl_db_env else ["--profile", "postgres-exposed"]
-    )
-
-    args_list.extend(["--wait", "--build", "--remove-orphans"])
-    return args_list
 
 
 def _check_down_args(args: tuple[str, ...]) -> list:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,9 +165,8 @@ services:
         extra_hosts:
             - "host.docker.internal:host-gateway"
         depends_on:
-            postgres-exposed:
+            postgres:
                 condition: service_healthy
-                required: false
         healthcheck:
             test:
                 [
@@ -224,10 +223,6 @@ services:
         depends_on:
             postgres:
                 condition: service_healthy
-                required: false
-            postgres-exposed:
-                condition: service_healthy
-                required: false
             orthanc-anon:
                 condition: service_started
         healthcheck:
@@ -295,10 +290,6 @@ services:
                 condition: service_healthy
             postgres:
                 condition: service_healthy
-                required: false
-            postgres-exposed:
-                condition: service_healthy
-                required: false
             hasher-api:
                 condition: service_healthy
         ports:
@@ -368,8 +359,7 @@ services:
 
     ################################################################################
     # Data Stores
-    postgres-exposed:
-        profiles: [postgres-exposed]
+    postgres:
         build:
             context: .
             dockerfile: ./docker/postgres/Dockerfile
@@ -389,33 +379,6 @@ services:
               target: /var/lib/postgresql/data
         ports:
             - "${CLI_PIXL_DB_PORT}:5432"
-        healthcheck:
-            test: ["CMD", "pg_isready", "-U", "${ORTHANC_RAW_DB_USER}", "--dbname", "${ORTHANC_RAW_DB_NAME}"]
-            interval: 10s
-            timeout: 30s
-            retries: 5
-        restart: always
-        networks:
-            - pixl-net
-    postgres:
-        profiles: [postgres]
-        build:
-            context: .
-            dockerfile: ./docker/postgres/Dockerfile
-            args:
-                <<: *build-args-common
-        environment:
-            POSTGRES_USER: ${ORTHANC_RAW_DB_USER}
-            POSTGRES_PASSWORD: ${ORTHANC_RAW_DB_PASSWORD}
-            POSTGRES_DB: ${ORTHANC_RAW_DB_NAME}
-            PGTZ: ${TZ:-Europe/London}
-        env_file:
-            - ./docker/common.env
-        command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
-        volumes:
-            - type: volume
-              source: postgres-data
-              target: /var/lib/postgresql/data
         healthcheck:
             test: ["CMD", "pg_isready", "-U", "${ORTHANC_RAW_DB_USER}", "--dbname", "${ORTHANC_RAW_DB_NAME}"]
             interval: 10s

--- a/test/.env
+++ b/test/.env
@@ -8,13 +8,12 @@ PIXL_MAX_MESSAGES_IN_FLIGHT=5
 TZ=Europe/London
 
 # PIXL PostgreSQL instance
-PIXL_DB_HOST=postgres-pixl-db
+PIXL_DB_HOST=postgres
 PIXL_DB_PORT=5432
 PIXL_DB_NAME=pixl
 PIXL_DB_USER=pixl_db_username
 PIXL_DB_PASSWORD=pixl_db_password
 SKIP_ALEMBIC=false
-EXTERNAL_PIXL_DB=true
 
 # PIXL DB Postgres host
 CLI_PIXL_DB_HOST=localhost
@@ -23,8 +22,8 @@ CLI_PIXL_DB_HOST=localhost
 ORTHANC_RAW_DB_HOST=postgres
 ORTHANC_RAW_DB_PORT=5432
 ORTHANC_RAW_DB_NAME=pixl
-ORTHANC_RAW_DB_USER=orthanc_raw_db_username
-ORTHANC_RAW_DB_PASSWORD=orthanc_raw_db_password
+ORTHANC_RAW_DB_USER=pixl_db_username
+ORTHANC_RAW_DB_PASSWORD=pixl_db_password
 
 # Exposed ports
 HASHER_API_PORT=7010

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -13,7 +13,6 @@
 #  limitations under the License.
 volumes:
     vna-qr-data:
-    postgres-pixl-db-data:
 
 networks:
     pixl-net:
@@ -74,27 +73,3 @@ services:
             retries: 2
             interval: 3s
             timeout: 2s
-    postgres-pixl-db:
-        build:
-            context: ../
-            dockerfile: ./docker/postgres/Dockerfile
-        environment:
-            POSTGRES_USER: ${PIXL_DB_USER}
-            POSTGRES_PASSWORD: ${PIXL_DB_PASSWORD}
-            POSTGRES_DB: ${PIXL_DB_NAME}
-            PGTZ: ${TZ:-Europe/London}
-        command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
-        volumes:
-            - type: volume
-              source: postgres-pixl-db-data
-              target: /var/lib/postgresql/data
-        ports:
-            - "${CLI_PIXL_DB_PORT}:5432"
-        healthcheck:
-            test: ["CMD", "pg_isready", "-U", "${PIXL_DB_USER}", "--dbname", "${PIXL_DB_NAME}"]
-            interval: 10s
-            timeout: 30s
-            retries: 5
-        restart: always
-        networks:
-            - pixl-net

--- a/test/run-system-test.sh
+++ b/test/run-system-test.sh
@@ -28,14 +28,14 @@ setup() {
     # Warning: Requires to be run from the project root
     (
     	cd "${PACKAGE_DIR}"
-    	docker compose --env-file test/.env --env-file test/.secrets.env --profile postgres -p system-test up --wait -d --build
+    	docker compose --env-file test/.env --env-file test/.secrets.env -p system-test up --wait -d --build
     )
 }
 
 teardown() {
     (
     	cd "${PACKAGE_DIR}"
-    	docker compose -f docker-compose.yml -f test/docker-compose.yml --profile postgres -p system-test down --volumes
+    	docker compose -f docker-compose.yml -f test/docker-compose.yml -p system-test down --volumes
     )
 }
 


### PR DESCRIPTION
Fixes #597 

- Remove use of profiles with docker compose
- Always expose the `CLI_PIXL_DB_PORT` on the postgres container
- Remove `EXTERNAL_PIXL_DB` env var as we're no longer using profiles
- Remove second postgres container used in integration tests; use the same postgres instance for PIXL DB and Orthanc Raw
- We can still have PIXL DB running in an external postgres instance (by setting the relevant env vars), but we're not testing for this in CI
- Update docs to reflect changes
- tested on dev instance on GAE

<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
## Description
Fixes #{issue_number}: A few words or sentences describing the changes proposed in this pull request (PR).

## Type of change
Please delete options accordingly to the description.

<!-- Write an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Suggested Checklist
<!-- You do not need to complete all the items by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have passed on my local host device. (see further details at the [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md#local-testing) document)
- [ ] Make sure your branch is up-to-date with main branch. See [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md) for a general example to syncronise your branch with the `main` branch.
- [ ] I have requested review to this PR.
- [ ] I have addressed and marked as resolved all the review comments in my PR.
- [ ] Finally, I have selected `squash and merge`

