### PR TITLE
Get remote query instances by recreating the query at the Instance level

### DIFF
--- a/pixl_imaging/src/pixl_imaging/_orthanc.py
+++ b/pixl_imaging/src/pixl_imaging/_orthanc.py
@@ -98,19 +98,23 @@ class Orthanc:
         """Get the content of a query answer"""
         return await self._get(f"/queries/{query_id}/answers/{answer_id}/content")
 
-    async def get_remote_query_instances(self, query_id: str) -> Any:
-        """Get the instances of a query, using DICOM timeout as can take a while"""
-        modality = await self._get_text(f"/queries/{query_id}/modality")
-        original_query = await self._get(f"/queries/{query_id}/query")
-        data = {
-            "Level": "Instance",
-            "Query": {param["Name"]: param["Value"] for param in original_query.values()},
-        }
-
-        return await self.query_remote(
-            data=data,
-            modality=modality,
+    async def get_remote_query_answer_series(self, query_id: str, answer_id: str) -> Any:
+        """Get the series of a query answer, using DICOM timeout as can take a while"""
+        response = await self._post(
+            f"/queries/{query_id}/answers/{answer_id}/query-series",
+            data={"Query": {}},
+            timeout=self.dicom_timeout,
         )
+        return response["ID"]
+
+    async def get_remote_query_answer_instances(self, query_id: str, answer_id: str) -> Any:
+        """Get the instances of a query answer, using DICOM timeout as can take a while"""
+        response = await self._post(
+            f"/queries/{query_id}/answers/{answer_id}/query-instances",
+            data={"Query": {}},
+            timeout=self.dicom_timeout,
+        )
+        return response["ID"]
 
     async def retrieve_study_from_remote(self, query_id: str) -> str:
         response = await self._post(
@@ -178,19 +182,6 @@ class Orthanc:
             ) as response,
         ):
             return await _deserialise(response)
-
-    async def _get_text(self, path: str, timeout: int | None = None) -> Any:
-        # Optionally override default http timeout
-        http_timeout = timeout or self.http_timeout
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(
-                f"{self._url}{path}",
-                auth=self._auth,
-                timeout=http_timeout,
-            ) as response,
-        ):
-            return await response.text()
 
     async def _post(self, path: str, data: dict, timeout: int | None = None) -> Any:
         # Optionally override default http timeout

--- a/pixl_imaging/src/pixl_imaging/_processing.py
+++ b/pixl_imaging/src/pixl_imaging/_processing.py
@@ -286,6 +286,9 @@ async def _get_missing_instances(
     missing_instances: list[dict[str, str]] = []
 
     # First query the VNA / PACS for the study instances
+    # We previously used the `query-instances` endpoint to get all instances in a Study, but the
+    # new VNA complains that the query has not SeriesInstanceUID. So now we get all series, iterate
+    # over the series, and get all instances in each series.
     study_query_answers = await orthanc_raw.get_remote_query_answers(study_query_id)
     instances_queries_and_answers = []
     for study_answer_id in study_query_answers:

--- a/pixl_imaging/src/pixl_imaging/_processing.py
+++ b/pixl_imaging/src/pixl_imaging/_processing.py
@@ -286,18 +286,13 @@ async def _get_missing_instances(
     missing_instances: list[dict[str, str]] = []
 
     # First query the VNA / PACS for the study instances
-    study_query_answers = await orthanc_raw.get_remote_query_answers(study_query_id)
-    instances_queries_and_answers = []
-    for answer_id in study_query_answers:
-        instances_query_id = await orthanc_raw.get_remote_query_answer_instances(
-            query_id=study_query_id, answer_id=answer_id
-        )
-        instances_query_answers = await orthanc_raw.get_remote_query_answers(instances_query_id)
-        instances_queries_and_answers.extend(
-            [(instances_query_id, answer) for answer in instances_query_answers]
-        )
-    num_remote_instances = len(instances_queries_and_answers)
+    instances_query_id = await orthanc_raw.get_remote_query_instances(
+        query_id=study_query_id,
+    )
+    instances_query_answers = await orthanc_raw.get_remote_query_answers(instances_query_id)
+    num_remote_instances = len(instances_query_answers)
 
+    # Get number of instances in Orthanc Raw
     num_local_instances = 0
     for resource in resources:
         study_statistics = await orthanc_raw.get_local_study_statistics(study_id=resource)
@@ -318,7 +313,7 @@ async def _get_missing_instances(
     # If the SOPInstanceUID is not in the list of instances in Orthanc Raw
     # retrieve the instance from the VNA / PACS
     query_tags = ["0020,000d", "0020,000e", "0008,0018"]
-    for instances_query_id, instance_query_answer in instances_queries_and_answers:
+    for instance_query_answer in instances_query_answers:
         instance_query_answer_content = await orthanc_raw.get_remote_query_answer_content(
             query_id=instances_query_id,
             answer_id=instance_query_answer,


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
## Description
Fixes #604 

- add a function `pixl_imaging._orthanc.Orthanc.get_remote_query_instances` that takes a `query_id` and re-submits the same query but at the `Instance` level
- remove `pixl_imaging._orthanc.Orthanc.get_remote_query_answer_instances`
- update `pixl_imaging._processing._get_missing_instances` to use the new function `get_remote_query_instances`

Edit: the above doens't work on the GAE as the VNA still complains that there is no `SeriesInstanceUID` in the instances query

Instead:

- use the `"/queries/{query_id}/answers/{answer_id}/query-seroes"` to get a list of the series in the study
- iterate over the series, and use the `"/queries/{query_id}/answers/{answer_id}/query-instances"` to get a list of the instances in each series

## Type of change
Please delete options accordingly to the description.

<!-- Write an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Suggested Checklist
<!-- You do not need to complete all the items by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have passed on my local host device. (see further details at the [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md#local-testing) document)
- [ ] Make sure your branch is up-to-date with main branch. See [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md) for a general example to syncronise your branch with the `main` branch.
- [ ] I have requested review to this PR.
- [ ] I have addressed and marked as resolved all the review comments in my PR.
- [ ] Finally, I have selected `squash and merge`

